### PR TITLE
Compatability for DGL later versions, where NodeDataLoader is replaced by DataLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ We provide six real-world datasets for our new benchmark task(```/dataset/```) a
 |__ hypergraph_pos.txt          # used for edge-dependent node labels; i-th line indicates depending on i-th hyperedge v_1's label, v_2's label, ... (same order as hypergraph.txt)
 |__ [valid/test]_hindex_0.txt   # used for splitting train/valid/test
 ```
-*Due to the large size of the dataset, only 'StackOverflowBiology' and 'DBLP' is visible now in the anonymous GitHub*
 
 (2) **Benchmark Task**
 

--- a/analysis.py
+++ b/analysis.py
@@ -111,7 +111,11 @@ try:
     sampler = dgl.dataloading.NeighborSampler(ls)
 except:
     sampler = dgl.dataloading.MultiLayerNeighborSampler(ls, False)
-dataloader = dgl.dataloading.NodeDataLoader( g, {"edge": target_data}, sampler, batch_size=256, shuffle=True, drop_last=False)
+try:
+    from dgl.dataloading import NodeDataLoader
+except:
+    from dgl.dataloading import DataLoader as NodeDataLoader
+dataloader = NodeDataLoader( g, {"edge": target_data}, sampler, batch_size=256, shuffle=True, drop_last=False)
 args.input_vdim = data.v_feat.size(1)
 args.input_edim = data.e_feat.size(1)
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -117,7 +117,11 @@ if args.embedder == "hcha" or args.embedder == "hnn":
     g = g.to(device)
     test_label = torch.LongTensor(test_label).to(device)
 else:
-    testdataloader = dgl.dataloading.NodeDataLoader(g, {"edge": test_data}, fullsampler, batch_size=args.bs, shuffle=False, drop_last=False)
+    try:
+        from dgl.dataloading import NodeDataLoader
+    except:
+        from dgl.dataloading import DataLoader as NodeDataLoader
+    testdataloader = NodeDataLoader(g, {"edge": test_data}, fullsampler, batch_size=args.bs, shuffle=False, drop_last=False)
 
 args.input_vdim = data.v_feat.size(1)
 args.input_edim = data.e_feat.size(1)

--- a/predict.py
+++ b/predict.py
@@ -81,7 +81,11 @@ if args.use_gpu:
     hedge_data = allhedges.to(device)
 else:
     hedge_data = allhedges
-dataloader = dgl.dataloading.NodeDataLoader( g, {"edge": hedge_data}, fullsampler, batch_size=args.bs, shuffle=False, drop_last=False) # , num_workers=4
+try:
+    from dgl.dataloading import NodeDataLoader
+except:
+    from dgl.dataloading import DataLoader as NodeDataLoader
+dataloader = NodeDataLoader( g, {"edge": hedge_data}, fullsampler, batch_size=args.bs, shuffle=False, drop_last=False) # , num_workers=4
 
 # init embedder
 args.input_vdim = 48

--- a/train.py
+++ b/train.py
@@ -345,10 +345,14 @@ if args.use_gpu:
     if args.evaltype == "test":
         test_data = test_data.to(device)
     data.e_feat = data.e_feat.to(device)
-dataloader = dgl.dataloading.NodeDataLoader( g, {"edge": train_data}, sampler, batch_size=args.bs, shuffle=True, drop_last=False) # , num_workers=4
-validdataloader = dgl.dataloading.NodeDataLoader( g, {"edge": valid_data}, sampler, batch_size=args.bs, shuffle=True, drop_last=False)
+try:
+    from dgl.dataloading import NodeDataLoader
+except:
+    from dgl.dataloading import DataLoader as NodeDataLoader
+dataloader = NodeDataLoader( g, {"edge": train_data}, sampler, batch_size=args.bs, shuffle=True, drop_last=False) # , num_workers=4
+validdataloader = NodeDataLoader( g, {"edge": valid_data}, sampler, batch_size=args.bs, shuffle=True, drop_last=False)
 if args.evaltype == "test":
-    testdataloader = dgl.dataloading.NodeDataLoader(g, {"edge": test_data}, fullsampler, batch_size=args.bs, shuffle=False, drop_last=False)
+    testdataloader = NodeDataLoader(g, {"edge": test_data}, fullsampler, batch_size=args.bs, shuffle=False, drop_last=False)
 
 args.input_vdim = data.v_feat.size(1)
 args.input_edim = data.e_feat.size(1)


### PR DESCRIPTION
Compatability for DGL later versions, where NodeDataLoader is replaced by DataLoader